### PR TITLE
Create function baka to output to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ skibidi main {
 ### Builtin functions
 
 - `yapping(string)`: equivalent to `printf`
+- `baka(string)`: equivalent to `fprintf(stderr...)`
 
 ### Operators
 

--- a/ast.c
+++ b/ast.c
@@ -48,6 +48,7 @@ extern bool set_variable(char *name, int value);
 extern int get_variable(char *name);
 extern void yyerror(const char *s);
 extern void yapping(const char *format, ...);
+extern void baka(const char *format, ...);
 
 /* Function implementations */
 
@@ -111,6 +112,14 @@ ASTNode *create_print_statement_node(ASTNode *expr)
 {
     ASTNode *node = malloc(sizeof(ASTNode));
     node->type = NODE_PRINT_STATEMENT;
+    node->data.op.left = expr;
+    return node;
+}
+
+ASTNode *create_error_statement_node(ASTNode *expr)
+{
+    ASTNode *node = malloc(sizeof(ASTNode));
+    node->type = NODE_ERROR_STATEMENT;
     node->data.op.left = expr;
     return node;
 }
@@ -239,6 +248,20 @@ void execute_statement(ASTNode *node)
         {
             int value = evaluate_expression(expr);
             yapping("%d\n", value);
+        }
+        break;
+    }
+    case NODE_ERROR_STATEMENT:
+    {
+        ASTNode *expr = node->data.op.left;
+        if (expr->type == NODE_STRING_LITERAL)
+        {
+            baka("%s\n", expr->data.name);
+        }
+        else
+        {
+            int value = evaluate_expression(expr);
+            baka("%d\n", value);
         }
         break;
     }

--- a/ast.h
+++ b/ast.h
@@ -40,6 +40,7 @@ typedef enum
     NODE_UNARY_OPERATION,
     NODE_FOR_STATEMENT,
     NODE_PRINT_STATEMENT,
+    NODE_ERROR_STATEMENT,
     NODE_STATEMENT_LIST,
     NODE_IF_STATEMENT,
     NODE_STRING_LITERAL,
@@ -119,6 +120,7 @@ ASTNode *create_operation_node(OperatorType op, ASTNode *left, ASTNode *right);
 ASTNode *create_unary_operation_node(OperatorType op, ASTNode *operand);
 ASTNode *create_for_statement_node(ASTNode *init, ASTNode *cond, ASTNode *incr, ASTNode *body);
 ASTNode *create_print_statement_node(ASTNode *expr);
+ASTNode *create_error_statement_node(ASTNode *expr);
 ASTNode *create_statement_list(ASTNode *statement, ASTNode *next_statement);
 ASTNode *create_if_statement_node(ASTNode *condition, ASTNode *then_branch, ASTNode *else_branch);
 ASTNode *create_string_literal_node(char *string);

--- a/examples/output_error.brainrot
+++ b/examples/output_error.brainrot
@@ -1,0 +1,6 @@
+skibidi main {
+    edging (1) {
+        baka("you sussy baka!");
+    }
+    bussin 0;
+}

--- a/lang.l
+++ b/lang.l
@@ -44,6 +44,7 @@ extern int yylineno;
 "schizo"         { return VOLATILE; }
 "goon"           { return WHILE; }
 "yapping"        { return YAPPING; }
+"baka"           { return BAKA; }
 
 "=="             { return EQ; }
 "!="             { return NE; }

--- a/lang.y
+++ b/lang.y
@@ -9,6 +9,7 @@
 int yylex(void);
 void yyerror(const char *s);
 void yapping(const char* format, ...);
+void baka(const char* format, ...);
 
 /* Symbol table to hold variable values */
 typedef struct {
@@ -62,7 +63,7 @@ ASTNode *root = NULL;
 }
 
 /* Define token types */
-%token SKIBIDI RIZZ YAPPING MAIN BUSSIN FLEX 
+%token SKIBIDI RIZZ YAPPING BAKA MAIN BUSSIN FLEX 
 %token PLUS MINUS TIMES DIVIDE MOD SEMICOLON COLON COMMA
 %token LPAREN RPAREN LBRACE RBRACE
 %token LT GT LE GE EQ NE EQUALS AND OR
@@ -80,6 +81,7 @@ ASTNode *root = NULL;
 %type <node> expression
 %type <node> for_statement
 %type <node> print_statement
+%type <node> error_statement
 %type <node> return_statement
 %type <node> init_expr condition increment
 %type <node> if_statement
@@ -126,6 +128,8 @@ statement:
     | for_statement
         { $$ = $1; }
     | print_statement SEMICOLON
+        { $$ = $1; }
+    | error_statement SEMICOLON
         { $$ = $1; }
     | return_statement SEMICOLON
         { $$ = $1; }
@@ -218,6 +222,11 @@ print_statement:
         { $$ = create_print_statement_node($3); }
     ;
 
+error_statement:
+    BAKA LPAREN expression RPAREN
+        { $$ = create_error_statement_node($3); }
+    ;
+
 return_statement:
     BUSSIN expression
         { $$ = $2; }
@@ -281,5 +290,12 @@ void yapping(const char* format, ...) {
     va_list args;
     va_start(args, format);
     vprintf(format, args);
+    va_end(args);
+}
+
+void baka(const char* format, ...) {
+    va_list args;
+    va_start(args, format);
+    vfprintf(stderr, format, args);
     va_end(args);
 }


### PR DESCRIPTION
Create function `baka(string)` to output to stderr. Its usage is pretty straightforward:

```
skibidi main {
    edging (1) {
        baka("you sussy baka!");
    }
    bussin 0;
}
```

You can check it is actually printing to the stderr using the following command:

```sh
[leonardo@archlinux brainrot]$ ./brainrot < examples/output_error.brainrot 2> stderr.txt
[leonardo@archlinux brainrot]$ cat stderr.txt 
you sussy baka!
```