### PR TITLE
refactor: change sigma keyword to sigma rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,40 +83,40 @@ skibidi main {
 
 ### Keywords
 
-| Brainrot | C Equivalent |
-| -------- | ------------ |
-| skibidi  | void         |
-| rizz     | int          |
-| cap      | bool         |
-| cooked   | auto         |
-| flex     | for          |
-| bussin   | return       |
-| edging   | if           |
-| amogus   | else         |
-| goon     | while        |
-| bruh     | break        |
-| grind    | continue     |
-| chad     | float        |
-| gigachad | double       |
-| yap      | char         |
-| grimace  | const        |
-| sigma    | case         |
-| based    | default      |
-| mewing   | do           |
-| gyatt    | enum         |
-| whopper  | extern       |
-| cringe   | goto         |
-| giga     | long         |
-| edgy     | register     |
-| soy      | short        |
-| nut      | signed       |
-| maxxing  | sizeof       |
-| salty    | static       |
-| gang     | struct       |
-| ohio     | switch       |
-| chungus  | union        |
-| nonut    | unsigned     |
-| schizo   | volatile     |
+| Brainrot   | C Equivalent |
+| ---------- | ------------ |
+| skibidi    | void         |
+| rizz       | int          |
+| cap        | bool         |
+| cooked     | auto         |
+| flex       | for          |
+| bussin     | return       |
+| edging     | if           |
+| amogus     | else         |
+| goon       | while        |
+| bruh       | break        |
+| grind      | continue     |
+| chad       | float        |
+| gigachad   | double       |
+| yap        | char         |
+| grimace    | const        |
+| sigma rule | case         |
+| based      | default      |
+| mewing     | do           |
+| gyatt      | enum         |
+| whopper    | extern       |
+| cringe     | goto         |
+| giga       | long         |
+| edgy       | register     |
+| soy        | short        |
+| nut        | signed       |
+| maxxing    | sizeof       |
+| salty      | static       |
+| gang       | struct       |
+| ohio       | switch       |
+| chungus    | union        |
+| nonut      | unsigned     |
+| schizo     | volatile     |
 
 ### Builtin functions
 

--- a/examples/switch_case.brainrot
+++ b/examples/switch_case.brainrot
@@ -1,13 +1,13 @@
 skibidi main {
     schizo rizz choice = 2;
     ohio (choice) {
-        sigma 1:
+        sigma rule 1:
             yapping("You chose 1, that's pretty sus!");
             bruh;
-        sigma 2:
+        sigma rule 2:
             yapping("You chose 2, gigachad move!");
             bruh;
-        sigma 3:
+        sigma rule 3:
             yapping("You chose 3, totally based!");
             bruh;
         based:

--- a/lang.l
+++ b/lang.l
@@ -18,7 +18,7 @@ extern int yylineno;
 "rizz"           { return RIZZ; }
 "main"           { return MAIN; }
 "bruh"           { return BREAK; }
-"sigma"          { return CASE; }
+"sigma rule"     { return CASE; }
 "yap"            { return CHAR; }
 "grimace"        { return CONST; }
 "grind"          { return CONTINUE; }


### PR DESCRIPTION
This PR changes the `sigma` keyword to `sigma rule` as requested by @unia909 and endorsed by some fellow chads in issue https://github.com/araujo88/brainrot/issues/3. 